### PR TITLE
Remove Rahul's profile and adjust layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,16 +198,6 @@
 
           <div class="col-12 col-md-6 col-lg-4">
             <div class="card h-100 shadow-sm border-0 rounded-4 team-card">
-              <img src="Rahul.png" class="w-100 rounded-4" style="height: 220px; object-fit: cover;" alt="Profile photo of Rahul">
-              <div class="card-body p-3">
-                <h3 class="h6 fw-bold mb-2">Rahul</h3>
-                <p class="mb-0">Leads partnerships with lawyers. Pursuing Social Work at IGNOU, he combines academic knowledge with practical engagement in justice initiatives. He envisions technology and partnerships working together to simplify complex legal processes.</p>
-              </div>
-            </div>
-          </div>
-
-          <div class="col-12 col-md-6 col-lg-4">
-            <div class="card h-100 shadow-sm border-0 rounded-4 team-card">
               <img src="Shivani.png" class="w-100 rounded-4" style="height: 220px; object-fit: cover;" alt="Profile photo of Shivani">
               <div class="card-body p-3">
                 <h3 class="h6 fw-bold mb-2">Shivani</h3>
@@ -225,7 +215,9 @@
               </div>
             </div>
           </div>
+        </div>
 
+        <div class="row g-4 justify-content-center">
           <div class="col-12 col-md-6 col-lg-4">
             <div class="card h-100 shadow-sm border-0 rounded-4 team-card">
               <img src="Mohit.png" class="w-100 rounded-4" style="height: 220px; object-fit: cover;" alt="Profile photo of Mohit Raj">


### PR DESCRIPTION
Remove Rahul's profile and re-arrange team cards in the "Who we are" section.

This updates the team layout to have 3 cards in the first row and 2 centered cards in the second row, as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b7f1bd1-7a0e-4390-8877-45f71a85cd99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b7f1bd1-7a0e-4390-8877-45f71a85cd99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

